### PR TITLE
Print links in login

### DIFF
--- a/motd
+++ b/motd
@@ -31,5 +31,8 @@ echo "Connected to SSH tunnel server"
 echo
 printf "%s (%s %s %s)\n" "$DISTRIB_DESCRIPTION" "$(uname -o)" "$(uname -r)" "$(uname -m)"
 echo
+echo -e "HTTP   -->       \033[4;32mhttp://${USER}.cht-tunnel.plip.com\033[0m"
+echo -e "HTTPS  -->  \033[4;32mhttps://${USER}-ssl.cht-tunnel.plip.com\033[0m"
+echo
 echo "Press 'ctrl + c' to exit"
 echo


### PR DESCRIPTION
Issue: #4 

Not sure if this PR will work, I didn't test it, more than locally running a bash script with the changes. If it works, it should show the links for the user like:

![Screenshot from 2021-06-17 18-20-10](https://user-images.githubusercontent.com/1608415/122474491-ae879880-cf99-11eb-9405-b5b41baced1e.png)

### Notes:
- Not tested
- It prints out both HTTP and HTTPS links, but when the tunnel is created, only one is available, so maybe adding one more variable or condition in the script could determine which one to show, if not possible to check that, taking into account that this is used by developers, I think is fine to show both and the dev will figure out which one to use.